### PR TITLE
Fix WaitGroup misuse

### DIFF
--- a/TestBalanceWithChannel.go
+++ b/TestBalanceWithChannel.go
@@ -12,31 +12,32 @@ func init() {
 	balance1 = 100
 }
 
-func deposit1(val int, wg sync.WaitGroup, ch chan bool) {
+func deposit1(val int, wg *sync.WaitGroup, ch chan bool) {
+	defer wg.Done()
 	ch <- true
 	fmt.Println("deposit before", balance1)
 	balance1 += val
 	fmt.Println("deposit after", balance1)
 	<-ch
 	time.Sleep(time.Millisecond * 10)
-	wg.Done()
 }
 
-func withdraw1(val int, wg sync.WaitGroup, ch chan bool) {
+func withdraw1(val int, wg *sync.WaitGroup, ch chan bool) {
+	defer wg.Done()
 	ch <- true
 	fmt.Println("withdraw before", balance1)
 	balance1 -= val
 	fmt.Println("withdraw after", balance1)
 	<-ch
-	wg.Done()
 }
 
 func main() {
 	ch := make(chan bool, 1)
 	var wg sync.WaitGroup
-	go deposit1(20, wg, ch)
-	go withdraw1(80, wg, ch)
-	go deposit1(40, wg, ch)
-	<-ch
-	fmt.Printf("Balance is: %d\n", balance)
+	wg.Add(3)
+	go deposit1(20, &wg, ch)
+	go withdraw1(80, &wg, ch)
+	go deposit1(40, &wg, ch)
+	wg.Wait()
+	fmt.Printf("Balance is: %d\n", balance1)
 }


### PR DESCRIPTION
## Summary
- fix WaitGroup usage in channel-based balance example
- simplify cleanup with `defer`

## Testing
- `go test ./...` *(fails: could not download modules)*

------
https://chatgpt.com/codex/tasks/task_e_683fbce82200833091a6ae6055488c69